### PR TITLE
WS | login with username ACE01-646

### DIFF
--- a/oauth2/authorization-code/strategy.js
+++ b/oauth2/authorization-code/strategy.js
@@ -12,10 +12,13 @@ const Strategy = function Strategy (options) {
 
   let authorizationURL = url.parse(options.base_url);
   authorizationURL.pathname = 'auth/v1/authorize';
+  authorizationURL.protocol = options.base_protocol;
   let tokenURL = url.parse(options.base_url);
   tokenURL.pathname = 'auth/v1/tokens';
+  tokenURL.protocol = options.base_protocol;
   let jwksURL = url.parse(options.base_url);
   jwksURL.pathname = 'auth/v1/certificates';
+  jwksURL.protocol = options.base_protocol;
 
   issuerOptions = {
     issuer: options.base_url,

--- a/oauth2/authorization-code/strategy.js
+++ b/oauth2/authorization-code/strategy.js
@@ -10,15 +10,12 @@ const Strategy = function Strategy (options) {
   if (!options.client_secret) { throw new Error('AuthorizationCodeStrategy requires client_secret to be set'); }
   if (!options.redirect_uri) { throw new Error('AuthorizationCodeStrategy requires redirect_uri to be set'); }
 
-  let authorizationURL = url.parse(options.base_url);
+  let authorizationURL = url.parse(options.base_protocol + options.base_url);
   authorizationURL.pathname = 'auth/v1/authorize';
-  authorizationURL.protocol = options.base_protocol;
-  let tokenURL = url.parse(options.base_url);
+  let tokenURL = url.parse(options.base_protocol + options.base_url);
   tokenURL.pathname = 'auth/v1/tokens';
-  tokenURL.protocol = options.base_protocol;
-  let jwksURL = url.parse(options.base_url);
+  let jwksURL = url.parse(options.base_protocol + options.base_url);
   jwksURL.pathname = 'auth/v1/certificates';
-  jwksURL.protocol = options.base_protocol;
 
   issuerOptions = {
     issuer: options.base_url,

--- a/oauth2/authorization-code/strategy.js
+++ b/oauth2/authorization-code/strategy.js
@@ -11,11 +11,11 @@ const Strategy = function Strategy (options) {
   if (!options.redirect_uri) { throw new Error('AuthorizationCodeStrategy requires redirect_uri to be set'); }
 
   let authorizationURL = url.parse(options.base_url);
-  authorizationURL.pathname = 'auth/authorize';
+  authorizationURL.pathname = 'auth/v1/authorize';
   let tokenURL = url.parse(options.base_url);
-  tokenURL.pathname = 'auth/token';
+  tokenURL.pathname = 'auth/v1/tokens';
   let jwksURL = url.parse(options.base_url);
-  jwksURL.pathname = 'auth/certificates';
+  jwksURL.pathname = 'auth/v1/certificates';
 
   issuerOptions = {
     issuer: options.base_url,

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -8,7 +8,7 @@ const Strategy = function Strategy (options) {
   if (!options) { throw new Error('PasswordStrategy requires options'); }
   if (!options.base_url) { throw new Error('PasswordStrategy requires base_url to be set'); }
   if (!options.client_id) { throw new Error('PasswordStrategy requires client_id to be set'); }
-  
+
   options.url = url.parse(options.base_protocol + options.base_url);
   options.url.pathname = '/auth/v1/tokens';
 

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -24,7 +24,6 @@ const Strategy = function Strategy (options) {
       }
     };
 
-    
     request.post(url.format(options.url), params, function (err, response, body) {
       try {
         const tokenset = JSON.parse(body);

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -5,7 +5,6 @@ const request = require('request');
 const jwt = require('jsonwebtoken');
 
 const Strategy = function Strategy (options) {
-  console.log(options)
   if (!options) { throw new Error('PasswordGrantStrategy requires options'); }
   if (!options.base_url) { throw new Error('PasswordGrantStrategy requires baseURL to be set'); }
   if (!options.client_id) { throw new Error('PasswordGrantStrategy requires clientID to be set'); }
@@ -37,7 +36,7 @@ const Strategy = function Strategy (options) {
     });
   });
 
-  this.name = 'pplsi-oauth2-password-grant';
+  this.name = 'pplsi-oauth2-password';
 }
 
 util.inherits(Strategy, LocalStrategy);

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -5,16 +5,23 @@ const request = require('request');
 const jwt = require('jsonwebtoken');
 
 const Strategy = function Strategy (options) {
+  console.log(options)
   if (!options) { throw new Error('PasswordGrantStrategy requires options'); }
-  if (!options.baseURL) { throw new Error('PasswordGrantStrategy requires baseURL to be set'); }
-  if (!options.clientID) { throw new Error('PasswordGrantStrategy requires clientID to be set'); }
-  options.url = url.parse(options.baseURL);
-  options.url.pathname = '/auth/tokens';
-  console.log('**************')
+  if (!options.base_url) { throw new Error('PasswordGrantStrategy requires baseURL to be set'); }
+  if (!options.client_id) { throw new Error('PasswordGrantStrategy requires clientID to be set'); }
+  options.url = url.parse(options.base_url);
+  options.url.pathname = '/auth/v1/tokens';
+  
   LocalStrategy.call(this, options, function(username, password, next) {
     const params = {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      form: { grant_type: 'password', scope: 'openid', username: username, password: password, client_id: options.clientID }
+      form: {
+        grant_type: 'password',
+        scope: 'openid',
+        username: username,
+        password: password,
+        client_id: options.client_id
+      }
     };
 
     

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -11,6 +11,7 @@ const Strategy = function Strategy (options) {
   
   options.url = url.parse(options.base_url);
   options.url.pathname = '/auth/v1/tokens';
+  options.url.protocol = options.base_protocol;
   
   LocalStrategy.call(this, options, function(username, password, next) {
     const params = {

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -5,19 +5,19 @@ const request = require('request');
 const jwt = require('jsonwebtoken');
 
 const Strategy = function Strategy (options) {
-  if (!options) { throw new Error('PasswordStrategy requires options'); }
-  if (!options.base_url) { throw new Error('PasswordStrategy requires base_url to be set'); }
-  if (!options.client_id) { throw new Error('PasswordStrategy requires client_id to be set'); }
-
-  options.url = url.parse(options.base_url);
-  options.url.pathname = '/auth/token';
-
+  if (!options) { throw new Error('PasswordGrantStrategy requires options'); }
+  if (!options.baseURL) { throw new Error('PasswordGrantStrategy requires baseURL to be set'); }
+  if (!options.clientID) { throw new Error('PasswordGrantStrategy requires clientID to be set'); }
+  options.url = url.parse(options.baseURL);
+  options.url.pathname = '/auth/tokens';
+  console.log('**************')
   LocalStrategy.call(this, options, function(username, password, next) {
     const params = {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      form: { grant_type: 'password', scope: 'openid', username: username, password: password, client_id: options.client_id }
+      form: { grant_type: 'password', scope: 'openid', username: username, password: password, client_id: options.clientID }
     };
 
+    
     request.post(url.format(options.url), params, function (err, response, body) {
       try {
         const tokenset = JSON.parse(body);
@@ -30,7 +30,7 @@ const Strategy = function Strategy (options) {
     });
   });
 
-  this.name = 'pplsi-oauth2-password';
+  this.name = 'pplsi-oauth2-password-grant';
 }
 
 util.inherits(Strategy, LocalStrategy);

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -6,8 +6,8 @@ const jwt = require('jsonwebtoken');
 
 const Strategy = function Strategy (options) {
   if (!options) { throw new Error('PasswordStrategy requires options'); }
-  if (!options.base_url) { throw new Error('PasswordStrategy requires baseURL to be set'); }
-  if (!options.client_id) { throw new Error('PasswordStrategy requires clientID to be set'); }
+  if (!options.base_url) { throw new Error('PasswordStrategy requires base_url to be set'); }
+  if (!options.client_id) { throw new Error('PasswordStrategy requires client_id to be set'); }
   
   options.url = url.parse(options.base_url);
   options.url.pathname = '/auth/v1/tokens';

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -8,6 +8,7 @@ const Strategy = function Strategy (options) {
   if (!options) { throw new Error('PasswordGrantStrategy requires options'); }
   if (!options.base_url) { throw new Error('PasswordGrantStrategy requires baseURL to be set'); }
   if (!options.client_id) { throw new Error('PasswordGrantStrategy requires clientID to be set'); }
+  
   options.url = url.parse(options.base_url);
   options.url.pathname = '/auth/v1/tokens';
   

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -5,9 +5,9 @@ const request = require('request');
 const jwt = require('jsonwebtoken');
 
 const Strategy = function Strategy (options) {
-  if (!options) { throw new Error('PasswordGrantStrategy requires options'); }
-  if (!options.base_url) { throw new Error('PasswordGrantStrategy requires baseURL to be set'); }
-  if (!options.client_id) { throw new Error('PasswordGrantStrategy requires clientID to be set'); }
+  if (!options) { throw new Error('PasswordStrategy requires options'); }
+  if (!options.base_url) { throw new Error('PasswordStrategy requires baseURL to be set'); }
+  if (!options.client_id) { throw new Error('PasswordStrategy requires clientID to be set'); }
   
   options.url = url.parse(options.base_url);
   options.url.pathname = '/auth/v1/tokens';

--- a/oauth2/password/strategy.js
+++ b/oauth2/password/strategy.js
@@ -9,10 +9,9 @@ const Strategy = function Strategy (options) {
   if (!options.base_url) { throw new Error('PasswordStrategy requires base_url to be set'); }
   if (!options.client_id) { throw new Error('PasswordStrategy requires client_id to be set'); }
   
-  options.url = url.parse(options.base_url);
+  options.url = url.parse(options.base_protocol + options.base_url);
   options.url.pathname = '/auth/v1/tokens';
-  options.url.protocol = options.base_protocol;
-  
+
   LocalStrategy.call(this, options, function(username, password, next) {
     const params = {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pplsi/passport-pplsi",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pplsi/passport-pplsi",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Passport strategies to authenticate against PPLSI.",
   "main": "index.js",
   "scripts": {

--- a/specs/oauth2Spec.js
+++ b/specs/oauth2Spec.js
@@ -12,7 +12,8 @@ describe('oauth2', function () {
     beforeEach(function () {
       Strategy = PassportPPLSI.OAuth2.PasswordStrategy;
       options = {
-        base_url: 'http://localhost:5000/',
+        base_url: 'localhost:5000/',
+        base_protocol: 'http://',
         client_id: 'some-client-id'
       };
       strategy = new Strategy(options);
@@ -42,12 +43,12 @@ describe('oauth2', function () {
           refresh_token: 'some-refresh-token',
           id_token: idToken
         };
-        scope = nock(options.base_url, {
+        scope = nock(options.base_protocol + options.base_url, {
           reqheaders: {
             'Content-Type': 'application/x-www-form-urlencoded'
           }
         })
-          .post('/auth/token', {
+          .post('/auth/v1/tokens', {
             grant_type: 'password',
             scope: 'openid',
             username: 'some-username',
@@ -143,7 +144,8 @@ describe('oauth2', function () {
         Strategy.__set__('Issuer', issuerSpy);
 
         options = {
-          base_url: 'http://localhost:5000/',
+          base_url: 'localhost:5000/',
+          base_protocol: 'http://',
           client_id: 'some-client-id',
           client_secret: 'some-client-secret',
           redirect_uri: 'http://localhost:3000/callback'
@@ -154,9 +156,9 @@ describe('oauth2', function () {
       it('is configured correctly', function () {
         const issuerOptions = {
           issuer: options.base_url,
-          authorization_endpoint: `${options.base_url}auth/authorize`,
-          token_endpoint: `${options.base_url}auth/token`,
-          jwks_uri: `${options.base_url}auth/certificates`
+          authorization_endpoint: `${options.base_protocol + options.base_url}auth/v1/authorize`,
+          token_endpoint: `${options.base_protocol + options.base_url}auth/v1/tokens`,
+          jwks_uri: `${options.base_protocol + options.base_url}auth/v1/certificates`
         };
 
         expect(Strategy.Issuer.getCall(0).args[0]).to.eql(issuerOptions);


### PR DESCRIPTION
This is part of work to allow login to accounts with username by hitting the adonis auth endpoints directly rather than going through id.adonis. It depends on changes to pplsi.web and accounts listed below.

**related pplsi.accounts pr**: https://github.com/LegalShield/pplsi.accounts/pull/190
**related pplsi.web pr**: https://github.com/LegalShield/pplsi.web
**story:** https://legalshield.atlassian.net/browse/ACE01-646

![signin](https://user-images.githubusercontent.com/25811267/54047488-25bc0880-41a5-11e9-8c16-4b6a1be928c6.gif)
